### PR TITLE
feat : 토큰 정보를 로컬 DB에 저장

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/example/companion_diary/login/MyApplication.kt
+++ b/app/src/main/java/com/example/companion_diary/login/MyApplication.kt
@@ -2,13 +2,19 @@ package com.example.companion_diary.login
 
 import android.app.Application
 import com.example.companion_diary.BuildConfig
+import com.example.companion_diary.utils.Preferences
 import com.kakao.sdk.common.KakaoSdk
 
 class MyApplication : Application() {
+
+    companion object{
+        lateinit var prefsManager : Preferences
+    }
+
     override fun onCreate() {
         super.onCreate()
         // 다른 초기화 코드들
-
+        prefsManager = Preferences(applicationContext)
         // Kakao SDK 초기화
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
     }

--- a/app/src/main/java/com/example/companion_diary/login/view/LoginActivity.kt
+++ b/app/src/main/java/com/example/companion_diary/login/view/LoginActivity.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import com.example.companion_diary.MainActivity
 import com.example.companion_diary.R
 import com.example.companion_diary.databinding.ActivityLoginBinding
+import com.example.companion_diary.login.MyApplication
 import com.example.companion_diary.login.api.TokenNetworkService
 import com.example.companion_diary.login.model.KakaoAuthViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -51,6 +52,7 @@ class LoginActivity : AppCompatActivity() {
                         val answer = result.result.jwt
                         if (answer.isNotEmpty()) {
                             val intent = Intent(this@LoginActivity, MainActivity::class.java)
+                            storeLoginToken(answer)
                             startActivity(intent)
                         }
                     }
@@ -67,6 +69,10 @@ class LoginActivity : AppCompatActivity() {
         }
 
 
+    }
+
+    private fun storeLoginToken(token : String){
+        MyApplication.prefsManager.setString("OAuthToken", token)
     }
 
     private fun loginAlertDialog(context : Context) {

--- a/app/src/main/java/com/example/companion_diary/utils/Preferences.kt
+++ b/app/src/main/java/com/example/companion_diary/utils/Preferences.kt
@@ -1,0 +1,16 @@
+package com.example.companion_diary.utils
+
+import android.content.Context
+
+class Preferences(context: Context) {
+    private val prefs = context.getSharedPreferences("pref_name", Context.MODE_PRIVATE)
+
+    fun getString(key: String, defValue: String): String {
+        return prefs.getString(key, defValue).toString()
+    }
+
+    fun setString(key: String, value: String) {
+        prefs.edit().putString(key, value).apply()
+
+    }
+}


### PR DESCRIPTION
# 토큰 정보를 로컬 DB에 저장
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
-  토큰 정보를 로컬 DB에 저장하였습니다.
- SharedPreferences는 싱글톤으로 구현하여 사용하였습니다.
- utils 패키지 내에 SharedPreferences 변수를 저장해두었습니다.